### PR TITLE
stdout and filepath fix for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+.vscode/

--- a/config.go
+++ b/config.go
@@ -5,6 +5,13 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Configure takes logging parameters and allows custom parameters.
+// file: 		Filepath to where the logging file is saved.
+// maxsize: 	Size of the file allowed in megabytes.
+// maxbackups: 	Maximum allowed backups of a single log file.
+// maxage:		Maximum allowed age of a log file.
+// compress:	Compress the logfile?
+// timefield: 	zerolog time format
 func Configure(file string, maxsize, maxbackups, maxage int, compress bool, timefield string) {
 	zerolog.TimeFieldFormat = timefield
 	l = zerolog.New(&lumberjack.Logger{

--- a/config.go
+++ b/config.go
@@ -26,7 +26,7 @@ func Configure(file string, maxsize, maxbackups, maxage int, compress bool, time
 	}).With().Timestamp().Logger()
 }
 
-func StdOutput() {
+func Stdout() {
 	l = zerolog.New(os.Stdout).
 		With().
 		Timestamp().

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"os"
-	"time"
 
 	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
@@ -32,14 +31,4 @@ func Stdout() {
 		Timestamp().
 		Logger()
 	l.Info().Msg("Testing Stdout")
-}
-
-func DefaultOutput() {
-	l = zerolog.New(&lumberjack.Logger{
-		Filename:   appdir + defdir + os.Args[0] + time.Now().UTC().String() + ".log",
-		MaxSize:    128,
-		MaxBackups: 3,
-		MaxAge:     1,
-		Compress:   true,
-	}).With().Timestamp().Logger()
 }

--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package logger
 
 import (
+	"os"
+	"time"
+
 	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
 )
@@ -20,5 +23,23 @@ func Configure(file string, maxsize, maxbackups, maxage int, compress bool, time
 		MaxBackups: maxbackups,
 		MaxAge:     maxage,
 		Compress:   compress,
+	}).With().Timestamp().Logger()
+}
+
+func StdOutput() {
+	l = zerolog.New(os.Stdout).
+		With().
+		Timestamp().
+		Logger()
+	l.Info().Msg("Testing Stdout")
+}
+
+func DefaultOutput() {
+	l = zerolog.New(&lumberjack.Logger{
+		Filename:   appdir + defdir + os.Args[0] + time.Now().UTC().String() + ".log",
+		MaxSize:    128,
+		MaxBackups: 3,
+		MaxAge:     1,
+		Compress:   true,
 	}).With().Timestamp().Logger()
 }

--- a/init.go
+++ b/init.go
@@ -3,7 +3,9 @@ package logger
 import (
 	"os"
 	"runtime"
+	"time"
 
+	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
 )
 
@@ -26,5 +28,11 @@ func init() {
 
 	// Allocate a new logger
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
-	DefaultFileOutput()
+	l = zerolog.New(&lumberjack.Logger{
+		Filename:   appdir + defdir + os.Args[0] + time.Now().UTC().String() + ".log",
+		MaxSize:    128,
+		MaxBackups: 3,
+		MaxAge:     1,
+		Compress:   true,
+	}).With().Timestamp().Logger()
 }

--- a/init.go
+++ b/init.go
@@ -12,6 +12,7 @@ import (
 var (
 	l      zerolog.Logger
 	appdir string
+	defdir string
 )
 
 func init() {
@@ -19,14 +20,16 @@ func init() {
 	switch runtime.GOOS {
 	case "windows":
 		appdir = os.Getenv("APPDATA")
+		defdir = "\\default\\"
 	default:
 		appdir = "/var/log"
+		defdir = "/default/"
 	}
 
 	// Allocate a new logger
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 	l = zerolog.New(&lumberjack.Logger{
-		Filename:   appdir + "/default/" + os.Args[0] + time.Now().UTC().String() + ".log",
+		Filename:   appdir + defdir + os.Args[0] + time.Now().UTC().String() + ".log",
 		MaxSize:    128,
 		MaxBackups: 3,
 		MaxAge:     1,

--- a/init.go
+++ b/init.go
@@ -3,9 +3,7 @@ package logger
 import (
 	"os"
 	"runtime"
-	"time"
 
-	"github.com/natefinch/lumberjack"
 	"github.com/rs/zerolog"
 )
 
@@ -28,11 +26,5 @@ func init() {
 
 	// Allocate a new logger
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
-	l = zerolog.New(&lumberjack.Logger{
-		Filename:   appdir + defdir + os.Args[0] + time.Now().UTC().String() + ".log",
-		MaxSize:    128,
-		MaxBackups: 3,
-		MaxAge:     1,
-		Compress:   true,
-	}).With().Timestamp().Logger()
+	DefaultFileOutput()
 }


### PR DESCRIPTION
stdout console function added
default function added so no hardcoding / able to reset to normal default output of spidernest-go/logger
informative comments for Configure added
defdir added to differentiate windows and unix forward/backward slash structure